### PR TITLE
Feature: Add streamlit secrets example, make tracing optional

### DIFF
--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,2 @@
+JDBC_URL = "jdbc:arrow-flight-sql://semantic-layer.cloud.getdbt.com:443?environmentId=218762&token=<DBT_CLOUD_SERVICE_TOKEN>" # Only necessary for the embedded tab
+OPENAI_API_KEY = "" #Input your open Open AI API Key

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,2 +1,2 @@
-JDBC_URL = "jdbc:arrow-flight-sql://semantic-layer.cloud.getdbt.com:443?environmentId=218762&token=<DBT_CLOUD_SERVICE_TOKEN>" # Only necessary for the embedded tab
+JDBC_URL = "jdbc:arrow-flight-sql://semantic-layer.cloud.getdbt.com:443?environmentId=<DBT_CLOUD_ENVIRONMENT_ID>&token=<DBT_CLOUD_SERVICE_TOKEN>" # Only necessary for the embedded tab
 OPENAI_API_KEY = "" #Input your open Open AI API Key

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 - rename the `secrets.toml.example` file in the `.streamlit` folder to `secrets.toml`.
 - populate your OpenAI API key
 - (Optional) Update the JDBC URL for your instance.
-  - Note: this is only necessary for the Embedded page. Since this page has hard coded logics, it's likely you won't need to use this field.
+  - Note: this is only necessary for the Embedded page. Since this page has hard coded logic, it's likely you won't need to use this field.
 
 Finally, run your app:
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ pip install uv && uv pip install -r requirements.txt
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
+4. Populate environment variables
+- copy the `secrets.toml.example` file in the `.streamlit` folder as `secrets.toml`.
+- populate your OpenAI API key
+- (Optional) Update the JDBC URL for your instance. Note, this is only necessary for the Embedded page. Since this page has hard coded logics, it's likely you won't need to use this field.
 
 Finally, run your app:
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 4. Populate environment variables
-- copy the `secrets.toml.example` file in the `.streamlit` folder as `secrets.toml`.
+- rename the `secrets.toml.example` file in the `.streamlit` folder to `secrets.toml`.
 - populate your OpenAI API key
-- (Optional) Update the JDBC URL for your instance. Note, this is only necessary for the Embedded page. Since this page has hard coded logics, it's likely you won't need to use this field.
+- (Optional) Update the JDBC URL for your instance.
+  - Note: this is only necessary for the Embedded page. Since this page has hard coded logics, it's likely you won't need to use this field.
 
 Finally, run your app:
 

--- a/pages/02_🧠_LLM.py
+++ b/pages/02_🧠_LLM.py
@@ -52,10 +52,16 @@ def set_question():
 
 # Set up tracing via Lanngsmith
 langchain_endpoint = "https://api.smith.langchain.com"
-client = Client(api_url=langchain_endpoint, api_key=st.secrets["LANGCHAIN_API_KEY"])
-ls_tracer = LangChainTracer(
-    project_name=st.secrets.get("LANGCHAIN_PROJECT", "default"), client=client
-)
+
+# Only leverage tracing if the API key is available
+if "LANGCHAIN_API_KEY" in st.secrets:
+    client = Client(api_url=langchain_endpoint, api_key=st.secrets["LANGCHAIN_API_KEY"])
+    ls_tracer = LangChainTracer(
+        project_name=st.secrets.get("LANGCHAIN_PROJECT", "default"), client=client
+    )
+else:
+    pass
+
 run_collector = RunCollectorCallbackHandler()
 cfg = RunnableConfig()
 cfg["callbacks"] = [ls_tracer, run_collector]


### PR DESCRIPTION
This PR adds a `secrets.toml` example file in the `.streamlit` folder. In addition, it ensures that tracing is only necessary if a `LANGCHAIN_API_KEY` is provided. Also updates readme.

This should make it easier for folks to fork & develop.